### PR TITLE
build: заменяет пакет cadesplugin_api.js на cadesplugin_api.js-actual…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1590,10 +1590,10 @@
         "unset-value": "^1.0.0"
       }
     },
-    "cadesplugin_api.js": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/cadesplugin_api.js/-/cadesplugin_api.js-2.3.5.tgz",
-      "integrity": "sha512-p8wi329HaJdzoBQBWo5Dc90XfnkeI7oALvy9xF4VVbTrL4kQVnlP68BR2kFkmAom+QlnmxvjL4oynrz5TJQq7Q==",
+    "cadesplugin_api.js-actual": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/cadesplugin_api.js-actual/-/cadesplugin_api.js-actual-2.4.1.tgz",
+      "integrity": "sha512-l0E9HhkZf7fJUPR05NVw+UfetboJsGDORCtyJ4l9lxTCOjXGC6hBhdn46ZEUtn3ASnQt5GNonmx8NYu3V7vlrg==",
       "dev": true
     },
     "callsites": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/node": "13.9.5",
     "@typescript-eslint/eslint-plugin": "2.25.0",
     "@typescript-eslint/parser": "2.25.0",
-    "cadesplugin_api.js": "2.3.5",
+    "cadesplugin_api.js-actual": "^2.4.1",
     "coveralls": "3.0.11",
     "cross-env": "7.0.2",
     "eslint": "6.8.0",

--- a/src/helpers/_afterPluginsLoaded.ts
+++ b/src/helpers/_afterPluginsLoaded.ts
@@ -13,7 +13,7 @@ export const _afterPluginsLoaded = <T extends (...args: any[]) => any>(
   return async function (...args: Parameters<T>): Promise<Unpromisify<ReturnType<T>>> {
     if (!isPluginLoaded) {
       try {
-        require('cadesplugin_api.js');
+        require('cadesplugin_api.js-actual');
       } catch (error) {
         console.error(error);
 


### PR DESCRIPTION
… для корректной работы с новой версией плагина КриптоПро